### PR TITLE
Use require 'buffer/' instead of 'buffer'

### DIFF
--- a/dist/binary.js
+++ b/dist/binary.js
@@ -12,7 +12,7 @@ var _fit = require('./fit');
 
 var _messages = require('./messages');
 
-var _buffer = require('buffer');
+var _buffer = require('buffer/');
 
 function addEndian(littleEndian, bytes) {
     var result = 0;

--- a/src/binary.js
+++ b/src/binary.js
@@ -1,6 +1,6 @@
-import {FIT} from './fit';
-import {getFitMessage, getFitMessageBaseType} from './messages';
-import {Buffer} from 'buffer';
+import { FIT } from './fit';
+import { getFitMessage, getFitMessageBaseType } from './messages';
+import { Buffer } from 'buffer/';
 
 export function addEndian(littleEndian, bytes) {
     let result = 0;
@@ -206,7 +206,7 @@ export function readRecord(blob, messageTypes, developerFields, startIndex, opti
         for (let i = 0; i < numberOfFields; i++) {
             const fDefIndex = startIndex + 6 + (i * 3);
             const baseType = blob[fDefIndex + 2];
-            const {field, type} = message.getAttributes(blob[fDefIndex]);
+            const { field, type } = message.getAttributes(blob[fDefIndex]);
             const fDef = {
                 type,
                 fDefNo: blob[fDefIndex],
@@ -277,7 +277,7 @@ export function readRecord(blob, messageTypes, developerFields, startIndex, opti
                 // Skip format of data if developer field
                 fields[fDef.name] = data;
             } else {
-                const {field, type, scale, offset} = message.getAttributes(fDef.fDefNo);
+                const { field, type, scale, offset } = message.getAttributes(fDef.fDefNo);
 
                 if (field !== 'unknown' && field !== '' && field !== undefined) {
                     fields[field] = applyOptions(formatByType(data, type, scale, offset), field, options);


### PR DESCRIPTION
This solves an error where buffer is not defined when not using browserify.

See https://github.com/calvinmetcalf/shapefile-js/issues/99 for more details.

I came across this while trying to use the library in an electron app