### PR TITLE
Store course_points as array rather than just the last one

### DIFF
--- a/src/fit-parser.js
+++ b/src/fit-parser.js
@@ -75,6 +75,7 @@ export default class FitParser {
     const applications = [];
     const fieldDescriptions = [];
     const dive_gases = [];
+    const course_points = [];
 
     let tempLaps = [];
     let tempRecords = [];
@@ -147,6 +148,9 @@ export default class FitParser {
         case 'dive_gas':
           dive_gases.push(message);
           break;
+        case 'course_point':
+          course_points.push(message);
+          break;
         default:
           if (messageType !== '') {
             fitObj[messageType] = message;
@@ -171,6 +175,7 @@ export default class FitParser {
       fitObj.field_descriptions = fieldDescriptions;
       fitObj.hrv = hrv;
       fitObj.dive_gases = dive_gases;
+      fitObj.course_points = course_points;
     }
 
     callback(null, fitObj);


### PR DESCRIPTION
Currently only the last `course_point` is being added to the parsed fit file object rather than an array of points.