### PR TITLE
Yuicompressor fix

### DIFF
--- a/src/binary.js
+++ b/src/binary.js
@@ -408,13 +408,13 @@ export function calculateCRC(blob, start, end) {
 
     let crc = 0;
     for (let i = start; i < end; i++) {
-        const byte = blob[i];
+        const byteVal = blob[i];
         let tmp = crcTable[crc & 0xF];
         crc = (crc >> 4) & 0x0FFF;
-        crc = crc ^ tmp ^ crcTable[byte & 0xF];
+        crc = crc ^ tmp ^ crcTable[byteVal & 0xF];
         tmp = crcTable[crc & 0xF];
         crc = (crc >> 4) & 0x0FFF;
-        crc = crc ^ tmp ^ crcTable[(byte >> 4) & 0xF];
+        crc = crc ^ tmp ^ crcTable[(byteVal >> 4) & 0xF];
     }
 
     return crc;

--- a/src/fit.js
+++ b/src/fit.js
@@ -1250,7 +1250,7 @@ export const FIT = {
       40: 'latvian_grid',
       41: 'swedish_ref_99_grid'
     },
-    switch: {
+    'switch': {
       0: 'off',
       1: 'on',
       2: 'auto',


### PR DESCRIPTION
I use java yuicompressor for minification. 
And it doesn't like 'switch' like option name without quotes.
And variable name 'byte' also is not recommended.
This small changes resolved my issue. Maybe it will help somebody else.