### PR TITLE
Fix support both summary first and last

### DIFF
--- a/dist/fit-parser.js
+++ b/dist/fit-parser.js
@@ -208,7 +208,10 @@ var FitParser = function () {
 
       if (isCascadeNeeded) {
         fitObj.activity = fitObj.activity || {};
-        fitObj.activity.sessions = (0, _helper.mapDataIntoSession)(sessions, laps, lengths, records);
+        laps = (0, _helper.mapDataIntoLap)(laps, 'records', records);
+        laps = (0, _helper.mapDataIntoLap)(laps, 'lengths', lengths);
+        sessions = (0, _helper.mapDataIntoSession)(sessions, laps);
+        fitObj.activity.sessions = sessions;
         fitObj.activity.events = events;
         fitObj.activity.hrv = hrv;
         fitObj.activity.device_infos = devices;

--- a/dist/helper.js
+++ b/dist/helper.js
@@ -3,8 +3,11 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
 var mapDataIntoLap = exports.mapDataIntoLap = function mapDataIntoLap(inputLaps, lapKey, data) {
-  var laps = JSON.parse(JSON.stringify(inputLaps));
+  var laps = [].concat(_toConsumableArray(inputLaps));
   var index = 0;
   for (var i = 0; i < laps.length; i++) {
     var lap = laps[i];
@@ -36,7 +39,7 @@ var mapDataIntoLap = exports.mapDataIntoLap = function mapDataIntoLap(inputLaps,
 };
 
 var mapDataIntoSession = exports.mapDataIntoSession = function mapDataIntoSession(inputSessions, laps) {
-  var sessions = JSON.parse(JSON.stringify(inputSessions));
+  var sessions = [].concat(_toConsumableArray(inputSessions));
   var lapIndex = 0;
   for (var i = 0; i < sessions.length; i++) {
     var session = sessions[i];

--- a/dist/helper.js
+++ b/dist/helper.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -10,16 +10,15 @@ var mapDataIntoLap = exports.mapDataIntoLap = function mapDataIntoLap(inputLaps,
     var lap = laps[i];
     var nextLap = laps[i + 1];
     var tempData = [];
-    var lapStartTime = new Date(lap.startTime).getTime();
+    var lapStartTime = new Date(lap.start_time).getTime();
     var nextLapStartTime = nextLap ? new Date(nextLap.start_time).getTime() : null;
     for (var j = index; j < data.length; j++) {
       var row = data[j];
       if (nextLap) {
         var timestamp = new Date(row.timestamp).getTime();
-        if (lapStartTime <= timestamp && nextLapStartTime >= timestamp) {
+        if (lapStartTime <= timestamp && nextLapStartTime > timestamp) {
           tempData.push(row);
-        } else if (nextLapStartTime < timestamp) {
-          laps[i][lapKey] = tempData;
+        } else if (nextLapStartTime <= timestamp) {
           index = j;
           break;
         }
@@ -36,11 +35,8 @@ var mapDataIntoLap = exports.mapDataIntoLap = function mapDataIntoLap(inputLaps,
   return laps;
 };
 
-var mapDataIntoSession = exports.mapDataIntoSession = function mapDataIntoSession(inputSessions, inputLaps, lengths, records) {
+var mapDataIntoSession = exports.mapDataIntoSession = function mapDataIntoSession(inputSessions, laps) {
   var sessions = JSON.parse(JSON.stringify(inputSessions));
-  var laps = JSON.parse(JSON.stringify(inputLaps));
-  laps = mapDataIntoLap(laps, 'lengths', lengths);
-  laps = mapDataIntoLap(laps, 'records', records);
   var lapIndex = 0;
   for (var i = 0; i < sessions.length; i++) {
     var session = sessions[i];
@@ -52,10 +48,9 @@ var mapDataIntoSession = exports.mapDataIntoSession = function mapDataIntoSessio
       var lap = laps[j];
       if (nextSession) {
         var lapStartTime = new Date(lap.start_time).getTime();
-        if (sessionStartTime <= lapStartTime && nextSessionStartTime >= lapStartTime) {
+        if (sessionStartTime <= lapStartTime && nextSessionStartTime > lapStartTime) {
           tempLaps.push(lap);
-        } else if (nextSessionStartTime < lapStartTime) {
-          sessions[i].laps = tempLaps;
+        } else if (nextSessionStartTime <= lapStartTime) {
           lapIndex = j;
           break;
         }

--- a/src/fit-parser.js
+++ b/src/fit-parser.js
@@ -1,5 +1,5 @@
 import { getArrayBuffer, calculateCRC, readRecord } from './binary';
-import { mapDataIntoSession } from './helper';
+import { mapDataIntoSession, mapDataIntoLap } from './helper';
 export default class FitParser {
   constructor(options = {}) {
     this.options = {
@@ -72,8 +72,8 @@ export default class FitParser {
     fitObj.protocolVersion = protocolVersion;
     fitObj.profileVersion = profileVersion;
 
-    const sessions = [];
-    const laps = [];
+    let sessions = [];
+    let laps = [];
     const records = [];
     const events = [];
     const hrv = [];
@@ -188,7 +188,10 @@ export default class FitParser {
 
     if (isCascadeNeeded) {
       fitObj.activity = fitObj.activity || {};
-      fitObj.activity.sessions = mapDataIntoSession(sessions, laps, lengths, records);
+      laps = mapDataIntoLap(laps, 'records', records);
+      laps = mapDataIntoLap(laps, 'lengths', lengths);
+      sessions = mapDataIntoSession(sessions, laps);
+      fitObj.activity.sessions = sessions;
       fitObj.activity.events = events;
       fitObj.activity.hrv = hrv;
       fitObj.activity.device_infos = devices;

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,5 +1,5 @@
 export const mapDataIntoLap = (inputLaps, lapKey, data) => {
-  const laps = JSON.parse(JSON.stringify(inputLaps));
+  const laps = [...inputLaps];
   let index = 0;
   for (let i = 0; i < laps.length; i++) {
     const lap = laps[i];
@@ -31,7 +31,7 @@ export const mapDataIntoLap = (inputLaps, lapKey, data) => {
 };
 
 export const mapDataIntoSession = (inputSessions, laps) => {
-  const sessions = JSON.parse(JSON.stringify(inputSessions));
+  const sessions = [...inputSessions];
   let lapIndex = 0;
   for (let i = 0; i < sessions.length; i++) {
     const session = sessions[i];

--- a/src/helper.js
+++ b/src/helper.js
@@ -5,16 +5,15 @@ export const mapDataIntoLap = (inputLaps, lapKey, data) => {
     const lap = laps[i];
     const nextLap = laps[i + 1];
     const tempData = [];
-    const lapStartTime = new Date(lap.startTime).getTime();
+    const lapStartTime = new Date(lap.start_time).getTime();
     const nextLapStartTime = nextLap ? new Date(nextLap.start_time).getTime() : null;
     for (let j = index; j < data.length; j++) {
       const row = data[j];
       if (nextLap) {
         const timestamp = new Date(row.timestamp).getTime();
-        if (lapStartTime <= timestamp && nextLapStartTime >= timestamp) {
+        if (lapStartTime <= timestamp && nextLapStartTime > timestamp) {
           tempData.push(row);
-        } else if (nextLapStartTime < timestamp) {
-          laps[i][lapKey] = tempData;
+        } else if (nextLapStartTime <= timestamp) {
           index = j;
           break;
         }
@@ -31,11 +30,8 @@ export const mapDataIntoLap = (inputLaps, lapKey, data) => {
   return laps;
 };
 
-export const mapDataIntoSession = (inputSessions, inputLaps, lengths, records) => {
+export const mapDataIntoSession = (inputSessions, laps) => {
   const sessions = JSON.parse(JSON.stringify(inputSessions));
-  let laps = JSON.parse(JSON.stringify(inputLaps));
-  laps = mapDataIntoLap(laps, 'lengths', lengths);
-  laps = mapDataIntoLap(laps, 'records', records);
   let lapIndex = 0;
   for (let i = 0; i < sessions.length; i++) {
     const session = sessions[i];
@@ -47,10 +43,9 @@ export const mapDataIntoSession = (inputSessions, inputLaps, lengths, records) =
       const lap = laps[j];
       if (nextSession) {
         const lapStartTime = new Date(lap.start_time).getTime();
-        if (sessionStartTime <= lapStartTime && nextSessionStartTime >= lapStartTime) {
+        if (sessionStartTime <= lapStartTime && nextSessionStartTime > lapStartTime) {
           tempLaps.push(lap);
-        } else if (nextSessionStartTime < lapStartTime) {
-          sessions[i].laps = tempLaps;
+        } else if (nextSessionStartTime <= lapStartTime) {
           lapIndex = j;
           break;
         }


### PR DESCRIPTION
Found a bug report from @krzysztof-cislo.

This patch aims to fixed
- Missing `laps` inside `session`
- Incorrect scope of records inside lap (for example, in summary last, records should be with in [start time of the lap, timestamp of the lap) (my previous version was implemented with [start time of the lap, timestamp of the lap]
- Missing relationship inside `laps` for `both` mode

I also produce a JSON outputs. 
- triathlon_summary_last-1.8.4.json (created using fit-parser 1.8.4)
- output_summary_last.json (created using fit-parser this PR)
- output_summary_first.json (created using fit-parser this PR)

[Archive.zip](https://github.com/jimmykane/fit-parser/files/13427906/Archive.zip)

