### PR TITLE
feat: add new values for session & user profile

### DIFF
--- a/dist/fit.js
+++ b/dist/fit.js
@@ -135,6 +135,8 @@ var FIT = exports.FIT = {
       21: { field: 'temperature_setting', type: 'display_measure', scale: null, offset: 0, units: '' },
       22: { field: 'local_id', type: 'user_local_id', scale: null, offset: 0, units: '' },
       23: { field: 'global_id', type: 'byte', scale: null, offset: 0, units: '' },
+      28: { field: 'wake_time', type: 'localtime_into_day', scale: null, offset: 0, units: '' },
+      29: { field: 'sleep_time', type: 'localtime_into_day', scale: null, offset: 0, units: '' },
       30: { field: 'height_setting', type: 'display_measure', scale: null, offset: 0, units: '' }
     },
     4: {
@@ -359,7 +361,9 @@ var FIT = exports.FIT = {
       133: { field: 'avg_stance_time_balance', type: 'uint16', scale: 100, offset: 0, units: 'percent' },
       134: { field: 'avg_step_length', type: 'uint16', scale: 10, offset: 0, units: 'mm' },
       137: { field: 'total_anaerobic_effect', type: 'uint8', scale: 10, offset: 0, units: '' },
-      139: { field: 'avg_vam', type: 'uint16', scale: 1000, offset: 0, units: 'm/s' }
+      139: { field: 'avg_vam', type: 'uint16', scale: 1000, offset: 0, units: 'm/s' },
+      192: { field: 'workout_feel', type: 'uint8', scale: null, offset: 0, units: '' },
+      193: { field: 'workout_rpe', type: 'uint8', scale: 10, offset: 0, units: '' }
     },
     19: {
       name: 'lap',

--- a/src/fit.js
+++ b/src/fit.js
@@ -128,6 +128,8 @@ export const FIT = {
       21: { field: 'temperature_setting', type: 'display_measure', scale: null, offset: 0, units: '' },
       22: { field: 'local_id', type: 'user_local_id', scale: null, offset: 0, units: '' },
       23: { field: 'global_id', type: 'byte', scale: null, offset: 0, units: '' },
+      28: { field: 'wake_time', type: 'localtime_into_day', scale: null, offset: 0, units: '' },
+      29: { field: 'sleep_time', type: 'localtime_into_day', scale: null, offset: 0, units: '' },
       30: { field: 'height_setting', type: 'display_measure', scale: null, offset: 0, units: '' },
     },
     4: {
@@ -353,6 +355,8 @@ export const FIT = {
       134: { field: 'avg_step_length', type: 'uint16', scale: 10, offset: 0, units: 'mm' },
       137: { field: 'total_anaerobic_effect', type: 'uint8', scale: 10, offset: 0, units: '' },
       139: { field: 'avg_vam', type: 'uint16', scale: 1000, offset: 0, units: 'm/s' },
+      192: { field: 'workout_feel', type: 'uint8', scale: null, offset: 0, units: '' },
+      193: { field: 'workout_rpe', type: 'uint8', scale: 10, offset: 0, units: '' },
     },
     19: {
       name: 'lap',


### PR DESCRIPTION
Based on fitsdk/Profile

Extracting two new fields from user_profile:

def: 28
name: wake_time
type: localtime_into_day
comment: Typical wake time

def: 29
name: sleep_time
type: localtime_into_day
comment: Typical bed time

And two new fields from session:

def: 192
name: workout_feel
type: uint8
comment: A 0-100 scale representing how a user felt while performing a workout. Low values are considered feeling bad, while high values are good.

def: 193
name: workout_rpe
type: uint8
comment: Common Borg CR10 / 0-10 RPE scale, multiplied 10x.. Aggregate score for all workouts in a single session.
